### PR TITLE
arch-cli-install: changes

### DIFF
--- a/arch-cli-install
+++ b/arch-cli-install
@@ -51,22 +51,23 @@ reads() {
     clear
     cat /proc/filesystems
     echo ""
-    read -p "Enter file system for root (eg. ext4) " FS
+    read -p "Enter file system for root (eg. ext4): " FS
     clear
-    read -p "Enter your prefered text editor (eg. vim)" EDITOR
-    read -p "Enter your username (eg. arch)" USERNAME
-    read -p "Enter your hostname (eg. archlinux)" EDITOR
-    read -p "Enter linux kernel type to install. Remember - in Arch repo there is only linux, linux-hardened, linux-lts, linux-rt, linux-rt-lts and linux-zen! (eg. linux-lts)" KERNEL
+    read -p "Enter your prefered text editor (eg. vim): " EDITOR
+    read -p "Enter your username (eg. arch): " USERNAME
+    read -p "Enter your hostname (eg. archlinux): " HOST
+    read -p "Enter linux kernel type to install. Remember - in Arch repo there is only linux, linux-hardened, linux-lts, linux-rt, linux-rt-lts and linux-zen! (eg. linux-lts): " KERNEL
     read -p "Use swap? (y/n): " SWP
 }
 
 party() {
     parted $DISK -- mklabel gpt
     parted $DISK -- mkpart ESP fat32 1MB 1GB
-    parted $DISK -- set 3 esp on
+    parted $DISK -- set 1 esp on
 }
 
 connect() {
+    mkfs.ext4 /dev/disk/by-partlabel/root
     mount /dev/disk/by-partlabel/root $DIR
     mkdir -p $DIR/boot
     mount /dev/disk/by-partlabel/ESP $DIR/boot
@@ -80,16 +81,18 @@ disks() {
             read -p "Enter how much GB swap will be. Rationally swap is 1/2 of your current RAM. " SWPGB
             echo "Swap option is enabled, swap is $SWPGB GB!"
             party
-            parted $DISK -- mkpart root $FS 1GB -$SWPGB
-            parted $DISK -- mkpart swap linux-swap $SWPGB 100%
+            parted $DISK -- mkpart root $FS 1GB -"$SWPGB"GB
+            parted $DISK -- mkpart swap linux-swap -"$SWPGB"GB 100%
             echo "Mounting disks into $DIR with swap enabled."
+            sleep 3
             connect
+            mkswap /dev/disk/by-partlabel/swap
             swapon /dev/disk/by-partlabel/swap
         ;;
         n | no | NO | No)
             echo "Swap option is disabled."
             party
-            parted $DISK -- mkpart root $FS 1GB -1GB
+            parted $DISK -- mkpart root $FS 1GB 100%
             echo "Mounting disks into $DIR with swap disabled."
             connect
         ;;
@@ -102,11 +105,11 @@ disks() {
 
 
 strap() {
-    reflector --latest 200 --protocol http,https --sort rate --save /etc/pacman.d/mirrorlist
+    reflector --latest 20 --protocol http,https --sort rate --save /etc/pacman.d/mirrorlist
     pacstrap $DIR base base-devel binutils $EDITOR
     genfstab -U $DIR >> $DIR/etc/fstab
-    cat "en_US.UTF-8 UTF-8" >> $DIR/etc/locale.gen
-    cat "LANG=en_US.UTF-8 UTF-8" >> $DIR/etc/locale.conf
+    echo "en_US.UTF-8 UTF-8" >> $DIR/etc/locale.gen
+    echo "LANG=en_US.UTF-8 UTF-8" >> $DIR/etc/locale.conf
     cat > $DIR/etc/hosts << EOF
 ####################
 127.0.0.1 localhost
@@ -122,10 +125,11 @@ Defaults:root,%wheel env_keep+=TERMINFO_DIRS
 Defaults:root,%wheel env_keep+=TERMINFO
 #############################################
 EOF
-    cat $HOST >> $DIR/etc/hostname
+    echo $HOST >> $DIR/etc/hostname
     sleep 5
     arch-chroot $DIR /bin/bash << EOF
-pacman -Syyu $KERNEL $KERNEL-headers linux-firmware
+locale-gen
+pacman -Syyu --noconfirm $KERNEL $KERNEL-headers linux-firmware
 useradd -m -U -G wheel $USERNAME
 bootctl enable
 exit

--- a/arch-cli-install
+++ b/arch-cli-install
@@ -67,7 +67,7 @@ party() {
 }
 
 connect() {
-    mkfs.ext4 /dev/disk/by-partlabel/root
+    mkfs.$FS /dev/disk/by-partlabel/root
     mount /dev/disk/by-partlabel/root $DIR
     mkdir -p $DIR/boot
     mount /dev/disk/by-partlabel/ESP $DIR/boot

--- a/arch-cli-install
+++ b/arch-cli-install
@@ -28,11 +28,11 @@ sets() {
 execute() {
     case $DFLTS in
         y | yes | YES | Yes)
+            reads
             disks
             strap
         ;;
         n | no | NO | No)
-            reads
             disks
             strap
         ;;


### PR DESCRIPTION
Line 54-59: cosmetic improvements
Line 66: fixed wrong partition number
Line 70: added `mkfs` command due to parted not creating a filesystem on the partition
Line 84-85: fixed partitioning
Line 87: added delay to allow OS to update information in `/dev/disk/by-partlabel/`
Line 89: added `mkswap` command due to parted not setting up a partition as Linux swap area
Line 95: fixed partitioning
Line 108: reduced the number of mirrors to 20 due to the fact that 200 mirrors take too long to be rated by the Reflector
Line 111-112, 128: replaced `cat` with `echo` due to `cat` is looking for file instead of string
Line 131: added missing `locale-gen` command
Line 132: added `--noconfirm` flag to `pacman` command
